### PR TITLE
Use correct branch when identifying packages

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -100,8 +100,8 @@ spec:
           value: $(params.git-url)
         - name: revision
           value: $(params.revision)
-        - name: depth
-          value: "0"
+        - name: fetchTags
+          value: "true"
         - name: ociStorage
           value: $(params.output-image).git
         - name: ociArtifactExpiresAfter

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -128,9 +128,9 @@ spec:
         - name: SOURCE_ARTIFACT
           value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
         - name: SCRIPT
-          # SCRIPT_OUTPUT_ARRAY env var is injected by the run-script Task
+          # SCRIPT_OUTPUT_ARRAY and SCRIPT_OUTPUT env vars are injected by the run-script Task
           value: |
-            ./hack/identify-packages packages.txt '{{target_branch}}' "${SCRIPT_OUTPUT_ARRAY}"
+            ./hack/identify-packages packages.txt '{{target_branch}}' "${SCRIPT_OUTPUT_ARRAY}" "${SCRIPT_OUTPUT}"
         - name: SCRIPT_RUNNER_IMAGE
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9:v1.19.3
         - name: HERMETIC
@@ -172,6 +172,10 @@ spec:
           - name: pathInRepo
             value: tasks/build-python-wheels-oci-ta.yaml
         resolver: git
+      when:
+        - input: "$(tasks.identify-packages.results.SCRIPT_OUTPUT)"
+          operator: in
+          values: ["has-packages"]
     - name: sast-snyk-check
       params:
         - name: image-digest

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -130,7 +130,7 @@ spec:
         - name: SCRIPT
           # SCRIPT_OUTPUT_ARRAY env var is injected by the run-script Task
           value: |
-            ./hack/identify-packages packages.txt "${SCRIPT_OUTPUT_ARRAY}"
+            ./hack/identify-packages packages.txt '{{target_branch}}' "${SCRIPT_OUTPUT_ARRAY}"
         - name: SCRIPT_RUNNER_IMAGE
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9:v1.19.3
         - name: HERMETIC

--- a/hack/identify-packages
+++ b/hack/identify-packages
@@ -1,22 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
-GIT_REF='main'
-
 PACKAGES_FILE="$1"
-RESULT_FILE="$2"
+REVISION="$2"
+RESULT_FILE="$3"
+
+echo "[DEBUG] PACKAGES_FILE=${PACKAGES_FILE} REVISION=${REVISION} RESULT_FILE=${RESULT_FILE}" >&2
 
 git remote -v
 
 set +e
-OLD_PACKAGES="$(git show "origin/${GIT_REF}:${PACKAGES_FILE}")"
+OLD_PACKAGES="$(git show "origin/${REVISION}:${PACKAGES_FILE}")"
 err="$?"
 set -e
 
 # 128 indicates the file does not exist at the provided git reference. This may be the case when
 # creating a new index, for example.
 if [[ $err -eq 128 ]]; then
-    echo "[DEBUG] ${PACKAGES_FILE} doesn't exist at ${GIT_REF} git reference, using empty file" >&2
+    echo "[DEBUG] ${PACKAGES_FILE} doesn't exist at ${REVISION} git reference, using empty file" >&2
     OLD_PACKAGES=""
 fi
 

--- a/hack/identify-packages
+++ b/hack/identify-packages
@@ -4,6 +4,7 @@ set -euo pipefail
 PACKAGES_FILE="$1"
 REVISION="$2"
 RESULT_FILE="$3"
+EMPTY_RESULT_FILE="$4"
 
 echo "[DEBUG] PACKAGES_FILE=${PACKAGES_FILE} REVISION=${REVISION} RESULT_FILE=${RESULT_FILE}" >&2
 
@@ -33,3 +34,10 @@ if [[ -n "$NEW_PACKAGES" ]]; then
 fi
 
 echo "${NEW_PACKAGES_JSON}" | tee "${RESULT_FILE}"
+
+if [[ "${NEW_PACKAGES_JSON}" == "[]" ]]; then
+    printf 'no-packages' | tee "${EMPTY_RESULT_FILE}"
+else
+    printf 'has-packages' | tee "${EMPTY_RESULT_FILE}"
+fi
+echo


### PR DESCRIPTION
## Summary by Sourcery

Pass the correct Git branch into the package-identification step of the Tekton build pipeline.

Enhancements:
- Add a '{{target_branch}}' argument to the identify-packages invocation in .tekton/build-pipeline.yaml
- Update hack/identify-packages to accept and use the branch parameter when determining packages