### PR TITLE
some small support matrix changes

### DIFF
--- a/docs/support_matrices.md
+++ b/docs/support_matrices.md
@@ -10,7 +10,7 @@
 
 ### Manylinux
 
-We target and guarantee `manylinux_2_28` compatibility.\
+We target `manylinux_2_28` compatibility.\
 Some wheels may be upgraded and support even older versions.\
 For example, `numpy-2.4.2-0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64`\
 This wheel has `manylinux_2_27` and `manylinux_2_28` compatibility.
@@ -19,9 +19,9 @@ This wheel has `manylinux_2_27` and `manylinux_2_28` compatibility.
 
 | 2.X | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 | 3.14 |
 | --- | --- | ---- | ---- | ---- | ---- | ---- | 
-| :x: | :x: | :x: | :x: |  :white_check_mark: | :soon:| :soon: |
+| :x: | :x: | :x: | :soon: |  :white_check_mark: | :soon:| :soon: |
 
-Note: Some pure-python wheels may have python2.X compatibility but we do not guarantee it.
+Note: Universal wheels may have python2.X compatibility but we do not guarantee functionality.
 
 [Python3.12.12 download](https://www.python.org/downloads/release/python-31212/)
 
@@ -35,8 +35,9 @@ Note: Some pure-python wheels may have python2.X compatibility but we do not gua
 
 ### Integration Tests
 
-We run integration tests against the following images / operating systems:
+We run [integration tests](https://github.com/calungaproject/plumbing/blob/main/tasks/install-and-import-wheels.yaml)
+against the following images / operating systems:
 
-| ubi9 | ubi10 | fedora43 | ubuntu24.04 | hummingbird/python3.12 |
-| --- | --- | --- | --- | --- |
-| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :soon: |
+| ubi8 | ubi9 | ubi10 | fedora43 | hummingbird/python3.12 | ubuntu24.04 |
+| --- | --- | --- | --- | --- | --- |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
## Summary by Sourcery

Update support matrix documentation for manylinux, Python versions, and integration test environments.

Documentation:
- Clarify manylinux compatibility statement and Python 2.X support note in the support matrix documentation.
- Revise the documented Python version support matrix to mark Python 3.11 as upcoming support instead of unsupported.
- Update integration test documentation to link to the test workflow and refresh the list of tested images and operating systems.