### PR TITLE
Add new github action for log forwarding

### DIFF
--- a/.github/workflows/forward_logs.yml
+++ b/.github/workflows/forward_logs.yml
@@ -1,0 +1,24 @@
+name: Log Forwarder
+on:
+  workflow_run:
+    workflows: ["Get New Package Versions"]
+    types: [completed]
+
+jobs:
+  upload-logs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download and Send Logs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LOGGING_URL: ${{ secrets.LOGGING_URL }}
+          LOGGING_TOKEN: ${{ secrets.LOGGING_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # to account for delays in GH API
+          sleep 10
+          gh run view ${{ github.event.workflow_run.id }} --log --repo ${{ github.repository }} > final.log
+
+          curl -X POST -T final.log "$LOGGING_URL" \
+          -H "Authorization: Splunk $LOGGING_TOKEN"


### PR DESCRIPTION
We have a requirement from ProdSec to forward logs from our "Get New Package Versions" action for auditing purposes. Cleanest solution was to add new action that will be triggered on completing the former action run. This way there is clean separation of concerns with 2 actions and no risk of logs not being forwarded if any of the previous steps failed in a fatal way.

JIRA: CALUNGA-228

## Summary by Sourcery

Build:
- Introduce a new GitHub Actions workflow that triggers on completion of 'Get New Package Versions' and posts the run logs to a configured logging service.