### PR TITLE
add info about uv to getting_started

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,8 +1,6 @@
-### General Info
+# Red Hat Trusted Libraries (RHTL) Getting Started Guide
 
-Trusted Libraries content is currently in Technology Preview. To learn more about this, check out [this resource](https://access.redhat.com/solutions/21101)
-
-### Service Account Setup
+## Service Account Setup
 
 Create a service account in the [terms-based registry](https://access.redhat.com/terms-based-registry/accounts)
 
@@ -11,16 +9,16 @@ Create a service account in the [terms-based registry](https://access.redhat.com
   `<password>` is your token. It's important to keep this private.
 
 
-### Setting up your environment
+## Setting up your environment
 
-To learn more about Trusted Libraries compatibility, check out our [Support Matrices.](support_matrices.md)
+To learn more about Red Hat Trusted Libraries compatibility, check out our [Support Matrices.](support_matrices.md)
 
 You need to have python3.12 installed on your system. At this time, all wheels in the trusted-libraries index
 are built with [Python3.12.12](https://www.python.org/downloads/release/python-31212/)
 
 You have a few options for setting up your python + pip environment to look at the Trusted Libraries index.
 
-#### pip
+### pip
 
 You can create a `pip.conf` file in your environment and `pip` will automatically find it.
 
@@ -40,11 +38,11 @@ You can place it for any user on your computer at `/etc/xdg/pip/pip.conf` or `/e
 
 To read more about this `pip.conf` setup, look [here](https://pip.pypa.io/en/stable/topics/configuration/)
 
-#### uv
+### uv
 
-If you use `uv` you can configure your `pyproject.toml` to look at the trusted libraries index.
+If you use `uv` you can configure your `pyproject.toml` to look at the RHTL index.
 
-```
+```toml
 [[tool.uv.index]]
 name = "trusted-libraries"
 url = "https://packages.redhat.com/trusted-libraries/python"
@@ -54,14 +52,14 @@ default = true
 
 You also need to export your credentials so `uv` can authenticate with the index.
 
-```
+```bash
 export UV_INDEX_INTERNAL_PROXY_USERNAME=<username>
 export UV_INDEX_INTERNAL_PROXY_PASSWORD=<password>
 ```
 
 To read more about `uv` configuration, look [here](https://docs.astral.sh/uv/concepts/indexes/)
 
-#### netrc
+### netrc
 
 Some tools also use `netrc` and you may want to configure the index there.
 
@@ -72,16 +70,16 @@ machine packages.redhat.com login <username> password <password>
 
 For more information on using `netrc` look [here](https://pip.pypa.io/en/stable/topics/authentication/#netrc-support)
 
-### Using the index
+## Using the index
 
-#### Installing with pip
+### Installing with pip
 Here are the steps needed to install packages from the index.
 
 Take a look at [Python Packaging User Guide](https://packaging.python.org/en/latest/tutorials/installing-packages/) for more information
 
 1. create a virtual environment `venv`.
 
-```
+```bash
 python3.12 -m venv venv
 source venv/bin/activate
 ```
@@ -89,7 +87,7 @@ source venv/bin/activate
 If you are choosing the local `pip.conf` strategy: `cp my-pip.conf venv/`
 
 Here are some options for installing from the index:
-```
+```bash
 pip install numpy
 pip install numpy==2.3.5
 pip install -r requirements.txt
@@ -100,7 +98,7 @@ pip install --only-binary=:all: -r requirements.txt
 
 To learn more about `pip install` go [here](https://pip.pypa.io/en/stable/cli/pip_install/)
 
-#### Installing with uv
+### Installing with uv
 
 To learn more about managing dependencies with `uv` go [here](https://docs.astral.sh/uv/concepts/projects/dependencies/)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -20,6 +20,8 @@ are built with [Python3.12.12](https://www.python.org/downloads/release/python-3
 
 You have a few options for setting up your python + pip environment to look at the Trusted Libraries index.
 
+#### pip
+
 You can create a `pip.conf` file in your environment and `pip` will automatically find it.
 
 You have a few options on where you place it, which will be detailed below.
@@ -38,6 +40,29 @@ You can place it for any user on your computer at `/etc/xdg/pip/pip.conf` or `/e
 
 To read more about this `pip.conf` setup, look [here](https://pip.pypa.io/en/stable/topics/configuration/)
 
+#### uv
+
+If you use `uv` you can configure your `pyproject.toml` to look at the trusted libraries index.
+
+```
+[[tool.uv.index]]
+name = "trusted-libraries"
+url = "https://packages.redhat.com/trusted-libraries/python"
+# use RHTL index as your default index
+default = true
+```
+
+You also need to export your credentials so `uv` can authenticate with the index.
+
+```
+export UV_INDEX_INTERNAL_PROXY_USERNAME=<username>
+export UV_INDEX_INTERNAL_PROXY_PASSWORD=<password>
+```
+
+To read more about `uv` configuration, look [here](https://docs.astral.sh/uv/concepts/indexes/)
+
+#### netrc
+
 Some tools also use `netrc` and you may want to configure the index there.
 
 Sample `~/.netrc`
@@ -49,7 +74,7 @@ For more information on using `netrc` look [here](https://pip.pypa.io/en/stable/
 
 ### Using the index
 
-#### Installing
+#### Installing with pip
 Here are the steps needed to install packages from the index.
 
 Take a look at [Python Packaging User Guide](https://packaging.python.org/en/latest/tutorials/installing-packages/) for more information
@@ -74,4 +99,8 @@ pip install --only-binary=:all: -r requirements.txt
 ```
 
 To learn more about `pip install` go [here](https://pip.pypa.io/en/stable/cli/pip_install/)
+
+#### Installing with uv
+
+To learn more about managing dependencies with `uv` go [here](https://docs.astral.sh/uv/concepts/projects/dependencies/)
 


### PR DESCRIPTION
## Summary by Sourcery

Document how to use the Trusted Libraries index with both pip and uv, including configuration and installation guidance.

Documentation:
- Add documentation for configuring uv with the Trusted Libraries index via pyproject.toml and environment variables.
- Clarify and restructure getting-started instructions by separating pip and uv setup and installation sections.