### PR TITLE
Move package versions from packages.txt into per-package JSON files

### DIFF
--- a/.github/workflows/get_new_package_versions.yml
+++ b/.github/workflows/get_new_package_versions.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: update the packages.txt
+      - name: update the package version
         env:
           update: ${{ matrix.update }}
         run: ./hack/replace-package "$update"
@@ -50,7 +50,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          add-paths: packages.txt
+          add-paths: onboarded_packages/
           commit-message: Automatic build ${{ matrix.update }}
           title: Automatic build ${{ matrix.update }}
           branch: update-${{ matrix.update }}

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -63,7 +63,7 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
-    - description: Git ref to use for comparing packages.txt file
+    - description: Git ref to use for comparing onboarded packages
       name: prev-packages-ref
       type: string
     - default: "1"
@@ -140,7 +140,7 @@ spec:
         - name: SCRIPT
           # SCRIPT_OUTPUT_ARRAY and SCRIPT_OUTPUT env vars are injected by the run-script Task
           value: |
-            ./hack/identify-packages packages.txt '$(params.prev-packages-ref)' "${SCRIPT_OUTPUT_ARRAY}" "${SCRIPT_OUTPUT}"
+            ./hack/identify-packages '$(params.prev-packages-ref)' "${SCRIPT_OUTPUT_ARRAY}" "${SCRIPT_OUTPUT}"
         - name: SCRIPT_RUNNER_IMAGE
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9:v1.19.3
         - name: HERMETIC

--- a/hack/identify-packages
+++ b/hack/identify-packages
@@ -1,35 +1,55 @@
 #!/bin/bash
 set -euo pipefail
 
-PACKAGES_FILE="$1"
-REVISION="$2"
-RESULT_FILE="$3"
-EMPTY_RESULT_FILE="$4"
+PACKAGES_DIR="onboarded_packages"
+REVISION="$1"
+RESULT_FILE="$2"
+EMPTY_RESULT_FILE="$3"
 
-echo "[DEBUG] PACKAGES_FILE=${PACKAGES_FILE} REVISION=${REVISION} RESULT_FILE=${RESULT_FILE}" >&2
+echo "[DEBUG] REVISION=${REVISION} RESULT_FILE=${RESULT_FILE}" >&2
 
 git remote -v
 
+# Extract the "version" value from a JSON file using grep/sed.
+# jq not available in the Tekton SCRIPT_RUNNER_IMAGE
+extract_version() {
+    grep -o '"version": *"[^"]*"' | sed 's/.*"version": *"\([^"]*\)".*/\1/' || true
+}
+
+# Find JSON files that were added or modified compared to the revision
 set +e
-OLD_PACKAGES="$(git show "${REVISION}:${PACKAGES_FILE}")"
+CHANGED_FILES="$(git diff --name-only --diff-filter=AM "${REVISION}" -- "${PACKAGES_DIR}/")"
 err="$?"
 set -e
 
-# 128 indicates the file does not exist at the provided git reference. This may be the case when
-# creating a new index, for example.
-if [[ $err -eq 128 ]]; then
-    echo "[DEBUG] ${PACKAGES_FILE} doesn't exist at ${REVISION} git reference, using empty file" >&2
-    OLD_PACKAGES=""
+if [[ $err -ne 0 ]]; then
+    echo "[DEBUG] git diff failed (exit code ${err}), assuming all packages are new" >&2
+    CHANGED_FILES="$(find "${PACKAGES_DIR}" -name '*.json' -type f)"
 fi
 
-NEW_PACKAGES="$(comm -13 <(<<<"${OLD_PACKAGES}" sort -u) <(< "${PACKAGES_FILE}" sort -u))"
+NEW_PACKAGES=""
+for f in $CHANGED_FILES; do
+    if [[ -f "$f" ]]; then
+        PKG_NAME="$(basename "$f" .json)"
+        CURRENT_VERSION="$(extract_version < "$f")"
+        if [[ -z "$CURRENT_VERSION" ]]; then
+            continue
+        fi
+
+        OLD_VERSION="$(git show "${REVISION}:${f}" 2>/dev/null | extract_version || true)"
+
+        if [[ "$CURRENT_VERSION" != "$OLD_VERSION" ]]; then
+            NEW_PACKAGES="${NEW_PACKAGES}${PKG_NAME}==${CURRENT_VERSION}"$'\n'
+        fi
+    fi
+done
+NEW_PACKAGES="$(echo -n "$NEW_PACKAGES" | sed '/^$/d')"
 
 echo "Packages to build:"
 echo "${NEW_PACKAGES}"
 
 NEW_PACKAGES_JSON='[]'
 if [[ -n "$NEW_PACKAGES" ]]; then
-    # Turn the output into a JSON Array. `sed` is used to avoid a dependency on `jq`.
     NEW_PACKAGES_JSON="$(<<< "${NEW_PACKAGES}" sed -e ':a;N;$!ba;s/\n/", "/g' | sed -e 's/^/\["/' -e 's/$/"\]/')"
 fi
 

--- a/hack/onboard_package.py
+++ b/hack/onboard_package.py
@@ -5,7 +5,6 @@ import requests
 from packaging.version import InvalidVersion, Version, parse
 
 ONBOARDED_PKGS_DIR_PATH = "onboarded_packages"
-PACKAGES_TXT_PATH = "packages.txt"
 
 
 def ensure_dir():
@@ -36,12 +35,6 @@ def get_pypi_versions(package_name):
         print(f"Unexpected status code {resp.status_code} for package {package_name}")
         sys.exit(1)
     return resp.json()["releases"]
-
-
-def append_new_pkg_version_to_packages_txt(package, version):
-    line = f"{package}=={version}"
-    with open(PACKAGES_TXT_PATH, "a") as f:
-        f.write(f"{line}\n")
 
 
 def main():
@@ -88,9 +81,8 @@ def main():
 
     # ignore everything but the latest version
     ignored = non_semver + [v for v in semver if v != latest]
-    package_data = {"ignored_versions": ignored}
+    package_data = {"version": latest, "ignored_versions": ignored}
     save_onboarded_package(pkg_name, package_data)
-    append_new_pkg_version_to_packages_txt(pkg_name, latest)
 
 
 if __name__ == "__main__":

--- a/hack/replace-package
+++ b/hack/replace-package
@@ -3,7 +3,8 @@ set -euo pipefail
 
 NEW_PKG="$1"
 PKG_NAME="${NEW_PKG%%==*}"
-FILE="packages.txt"
+VERSION="${NEW_PKG##*==}"
+PKG_FILE="onboarded_packages/${PKG_NAME}.json"
 
-# Replace the line starting with PKG_NAME== with the NEW_PKG string
-sed -i "s|^$PKG_NAME==.*|$NEW_PKG|" "$FILE"
+# jq is in the github-action runner
+jq --arg v "$VERSION" '.version = $v' "$PKG_FILE" > "${PKG_FILE}.tmp" && mv "${PKG_FILE}.tmp" "$PKG_FILE"


### PR DESCRIPTION
Eliminate git merge conflicts caused by concurrent modifications to packages.txt by storing the version in each onboarded_packages/<pkg>.json file instead. Each PR now modifies exactly one JSON file, so concurrent onboarding and updates to different packages never conflict.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Store package versions in per-package JSON metadata instead of a shared packages.txt file to avoid merge conflicts and align automation with the new layout.

Enhancements:
- Persist each onboarded package's current version alongside its ignored versions in its onboarded_packages/<pkg>.json file instead of appending to packages.txt.
- Update onboarding and version-replacement scripts, as well as CI and Tekton pipeline steps, to work with per-package JSON metadata rather than the central packages.txt file.
- Adjust pipeline descriptions and automation metadata to reference onboarded package definitions instead of packages.txt.