### PR TITLE
Onboard rfc3986-validator

### DIFF
--- a/onboarded_packages/rfc3986-validator.json
+++ b/onboarded_packages/rfc3986-validator.json
@@ -1,0 +1,6 @@
+{
+    "version": "0.1.1",
+    "ignored_versions": [
+        "0.1.0"
+    ]
+}


### PR DESCRIPTION
## Summary
- Onboard rfc3986-validator at version 0.1.1

## Summary by Sourcery

New Features:
- Register the rfc3986-validator package (version 0.1.1) in the onboarded_packages configuration.