### PR TITLE
Exclude yanked releases from update checks

### DIFF
--- a/hack/check-for-updates.py
+++ b/hack/check-for-updates.py
@@ -67,7 +67,13 @@ async def _fetch_releases(session, url, pkg, semaphore, auth=None):
                     LOGGER.error(f"Error: {pkg} returned {response.status} from {url}")
                     return None
                 data = await response.json()
-                return set(data.get("releases", {}).keys())
+                releases = data.get("releases", {})
+                # exclude yanked releases
+                releases = {
+                    ver: files for ver, files in releases.items()
+                    if files and any(not f.get("yanked", False) for f in files)
+                }
+                return set(releases.keys())
         except Exception as e:
             LOGGER.error(f"Request failed for {pkg} at {url}: {e}")
             return None


### PR DESCRIPTION
Yanked PyPI releases were not being filtered out, which could cause the update checker to schedule builds for versions that should not be distributed.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Bug Fixes:
- Prevent the update checker from considering yanked PyPI releases as valid versions when scheduling builds.