### PR TITLE
Enable cron triggers on get_new_package_versions action

### DIFF
--- a/.github/workflows/get_new_package_versions.yml
+++ b/.github/workflows/get_new_package_versions.yml
@@ -7,8 +7,8 @@ permissions:
 
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: '0 */12 * * *'
+  schedule:
+    - cron: '0 */12 * * *'
 
 jobs:
   # first job will run a script to get a list of packages to update


### PR DESCRIPTION
JIRA: CALUNGA-266

## Summary by Sourcery

CI:
- Add a cron-based schedule trigger to the get_new_package_versions workflow to run every 12 hours.