### PR TITLE
CALUNGA-269: Disable Snapshot Supersession for On-Push

### DIFF
--- a/.tekton/calunga-v2-index-main-push.yaml
+++ b/.tekton/calunga-v2-index-main-push.yaml
@@ -8,6 +8,9 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    # Each push builds an independent package. Disable snapshot supersession so
+    # concurrent builds don't skip each other's releases.
+    test.appstudio.openshift.io/ignore-supersession: "true"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga-v2-index-main


### PR DESCRIPTION
Each merge to the index repo builds an independent package, but the integration service marks older snapshots as obsolete when multiple builds complete around the same time. Adding ignore-supersession ensures all snapshots are released regardless of build ordering.

## Summary by Sourcery

Build:
- Update Tekton push pipeline configuration to set ignore-supersession for index builds.