### PR TITLE
Add packaging to hack/requirements.in

### DIFF
--- a/hack/requirements.in
+++ b/hack/requirements.in
@@ -1,1 +1,2 @@
 aiohttp
+packaging

--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -129,7 +129,7 @@ aiohttp==3.13.5 \
     --hash=sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5 \
     --hash=sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540 \
     --hash=sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254
-    # via -r /home/jvulgan/Documents/index/hack/requirements.in
+    # via -r hack/requirements.in
 aiosignal==1.4.0 \
     --hash=sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e \
     --hash=sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7
@@ -426,6 +426,10 @@ multidict==6.7.1 \
     # via
     #   aiohttp
     #   yarl
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+    # via -r hack/requirements.in
 propcache==0.5.2 \
     --hash=sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427 \
     --hash=sha256:04dc2390d9edbbaef7461f33322555976ffddf0b650a038649d026358714e6c5 \


### PR DESCRIPTION
Needed for change introduced in 6d7d55de

JIRA: CALUNGA-284

## Summary by Sourcery

Build:
- Add the packaging dependency to hack/requirements.txt as generated from hack/requirements.in and fix the recorded source path comment.