### PR TITLE
Include start and end logs for get_new_package_versions

### DIFF
--- a/.github/workflows/get_new_package_versions.yml
+++ b/.github/workflows/get_new_package_versions.yml
@@ -17,6 +17,8 @@ jobs:
     outputs:
       updates: ${{ steps.run-script.outputs.updates }}
     steps:
+      - name: log start
+        run: echo "Workflow get_new_package_versions started at $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
       - name: checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: setup python
@@ -64,3 +66,11 @@ jobs:
         with:
           pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
           merge-method: rebase
+
+  log-end:
+    runs-on: ubuntu-latest
+    needs: [check-for-updates, create-prs]
+    if: always()
+    steps:
+      - name: log end
+        run: echo "Workflow get_new_package_versions ended at $(date -u +'%Y-%m-%dT%H:%M:%SZ')"


### PR DESCRIPTION
For audit reasons we need logs that can be used to identify the action run start and end.

JIRA: CALUNGA-273

## Summary by Sourcery

Add audit-friendly start and end logging around the get_new_package_versions workflow execution.

CI:
- Log the workflow start time at the beginning of the get_new_package_versions job.
- Introduce a final job that always logs the workflow end time after dependent jobs complete.