### PR TITLE
Enable trusted_task checks for Calunga builds

### DIFF
--- a/konflux/ecp.yaml
+++ b/konflux/ecp.yaml
@@ -46,9 +46,9 @@ spec:
           - tasks.required_tasks_found:init
           # TODO: No tests are executed during the build.
           - test.test_data_found
-          # TODO: Need to make sure our build task becomes trusted.
-          - trusted_task.trusted
-          - slsa_build_scripted_build.image_built_by_trusted_task
+          # CTRL-004: trusted_task and slsa_build_scripted_build exclusions removed.
+          # build-python-wheels-oci-ta is now trusted via trusted_task_rules in
+          # github.com/calungaproject/plumbing//policy-data
           # TODO: OCI artifacts don't have labels.
           - labels
         include:
@@ -56,6 +56,8 @@ spec:
       data:
         - github.com/release-engineering/rhtap-ec-policy//data
         - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        # CTRL-004: trusted_task_rules for Calunga-owned build task
+        - github.com/calungaproject/plumbing//policy-data
       name: Default
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:konflux


### PR DESCRIPTION
Add the Calunga plumbing policy-data as an EC data source and remove the trusted_task.trusted and slsa_build_scripted_build exclusions from the tenant ECP. The build-python-wheels-oci-ta task is now verified via trusted_task_rules.

## Summary by Sourcery

Update Konflux enterprise contract policy configuration to rely on Calunga plumbing policy data for trusted task verification.

Enhancements:
- Remove explicit exclusions for trusted_task and scripted build checks from the tenant enterprise contract policy, relying instead on trusted_task_rules for verification.
- Add Calunga plumbing policy-data as an additional enterprise contract data source for the default policy set.