### PR TITLE
CALUNGA-279: Skip PR Pipeline for Non-Package Changes

### DIFF
--- a/.tekton/calunga-v2-index-main-pull-request.yaml
+++ b/.tekton/calunga-v2-index-main-pull-request.yaml
@@ -8,7 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "main"
+      && files.all.exists(x, x.matches('^onboarded_packages/'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga-v2-index-main


### PR DESCRIPTION
Add CEL path filter to PR PipelineRun to skip the Konflux build pipeline and integration tests when a PR touches only infrastructure files (.tekton/, hack/, docs/, etc.). Packages continue to trigger the full pipeline. This resolves merge friction for infrastructure-only changes like the 4-day delay in PR #2958.

Assisted-by: Claude

## Summary by Sourcery

Build:
- Update Tekton PR pipeline CEL filter to require changes under onboarded_packages for the pipeline to execute.